### PR TITLE
Fix FinanceDateProvider to use EvakaClock

### DIFF
--- a/service/src/main/kotlin/fi/ouka/evakaoulu/util/FinanceDateProvider.kt
+++ b/service/src/main/kotlin/fi/ouka/evakaoulu/util/FinanceDateProvider.kt
@@ -4,39 +4,40 @@
 
 package fi.ouka.evakaoulu.util
 
+import fi.espoo.evaka.shared.domain.EvakaClock
+import fi.espoo.evaka.shared.domain.RealEvakaClock
 import org.springframework.stereotype.Component
-import java.time.LocalDate
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 
 @Component
 class FinanceDateProvider(
-    val currentDate: LocalDate = LocalDate.now(),
+    val evakaClock: EvakaClock = RealEvakaClock(),
 ) {
     fun currentDate(): String {
         val invoiceIdFormatter = DateTimeFormatter.ofPattern("yyyyMMdd")
-        return currentDate.format(invoiceIdFormatter)
+        return evakaClock.today().format(invoiceIdFormatter)
     }
 
     fun previousMonth(): String {
-        val previousMonth = currentDate.minusMonths(1)
+        val previousMonth = evakaClock.today().minusMonths(1)
         val titleFormatter = DateTimeFormatter.ofPattern("MM.yyyy")
         return previousMonth.format(titleFormatter)
     }
 
     fun currentDateWithAbbreviatedYear(): String {
         val invoiceIdFormatter = DateTimeFormatter.ofPattern("yyMMdd")
-        return currentDate.format(invoiceIdFormatter)
+        return evakaClock.today().format(invoiceIdFormatter)
     }
 
     fun previousMonthLastDate(): String {
-        val previousMonthlastDate = YearMonth.from(currentDate).minusMonths(1).atEndOfMonth()
+        val previousMonthlastDate = YearMonth.from(evakaClock.today()).minusMonths(1).atEndOfMonth()
         val invoiceIdFormatter = DateTimeFormatter.ofPattern("yyMMdd")
         return previousMonthlastDate.format(invoiceIdFormatter)
     }
 
     fun previousMonthYYMM(): String {
-        val previousMonth = currentDate.minusMonths(1)
+        val previousMonth = evakaClock.today().minusMonths(1)
         val titleFormatter = DateTimeFormatter.ofPattern("yyMM")
         return previousMonth.format(titleFormatter)
     }

--- a/service/src/test/kotlin/fi/ouka/evakaoulu/invoice/service/ProEInvoiceGeneratorTest.kt
+++ b/service/src/test/kotlin/fi/ouka/evakaoulu/invoice/service/ProEInvoiceGeneratorTest.kt
@@ -5,14 +5,14 @@
 package fi.ouka.evakaoulu.invoice.service
 
 import fi.espoo.evaka.invoicing.domain.InvoiceDetailed
+import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.ouka.evakaoulu.util.FieldType
 import fi.ouka.evakaoulu.util.FinanceDateProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
 
 internal class ProEInvoiceGeneratorTest {
-    val financeDateProvider = FinanceDateProvider(LocalDate.of(2022, 5, 5))
+    val financeDateProvider = FinanceDateProvider(MockEvakaClock(2022, 5, 5, 12, 34, 56))
     val proEInvoiceGenerator = ProEInvoiceGenerator(InvoiceChecker(), financeDateProvider)
 
     @Test

--- a/service/src/test/kotlin/fi/ouka/evakaoulu/payment/service/ProEPaymentGeneratorTest.kt
+++ b/service/src/test/kotlin/fi/ouka/evakaoulu/payment/service/ProEPaymentGeneratorTest.kt
@@ -4,10 +4,10 @@
 
 package fi.ouka.evakaoulu.payment.service
 
+import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.ouka.evakaoulu.util.FinanceDateProvider
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
 
 class ProEPaymentGeneratorTest {
     @Test
@@ -64,7 +64,12 @@ class ProEPaymentGeneratorTest {
 
     @Test
     fun `should check that payment format is a proper one also with invoice function number`() {
-        val proEPaymentGenerator = ProEPaymentGenerator(PaymentChecker(), FinanceDateProvider(LocalDate.of(2024, 1, 5)), BicMapper())
+        val proEPaymentGenerator =
+            ProEPaymentGenerator(
+                PaymentChecker(),
+                FinanceDateProvider(MockEvakaClock(2024, 1, 5, 12, 34, 56)),
+                BicMapper(),
+            )
         val validPayment = validPayment()
         val otherPaymentUnit = validPaymentUnit().copy(providerId = "OTHERPROVIDERID")
         val otherPayment = validPayment().copy(unit = otherPaymentUnit)

--- a/service/src/test/kotlin/fi/ouka/evakaoulu/util/FinanceDateProviderTest.kt
+++ b/service/src/test/kotlin/fi/ouka/evakaoulu/util/FinanceDateProviderTest.kt
@@ -4,9 +4,11 @@
 
 package fi.ouka.evakaoulu.invoice.service
 
+import fi.espoo.evaka.shared.domain.MockEvakaClock
 import fi.ouka.evakaoulu.util.FinanceDateProvider
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.Duration
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -24,7 +26,7 @@ class FinanceDateProviderTest {
 
     @Test
     fun `should obey the date the LocalDate parameter if given`() {
-        val financeDateProvider = FinanceDateProvider(LocalDate.of(2025, 7, 14))
+        val financeDateProvider = FinanceDateProvider(MockEvakaClock(2025, 7, 14, 12, 34, 56))
         val expectedDate = "20250714"
 
         val actualDate = financeDateProvider.currentDate()
@@ -34,14 +36,14 @@ class FinanceDateProviderTest {
 
     @Test
     fun `should return correct previous month`() {
-        val financeDateProvider = FinanceDateProvider(LocalDate.of(2025, 7, 14))
+        val financeDateProvider = FinanceDateProvider(MockEvakaClock(2025, 7, 14, 12, 34, 56))
         val expectedDate = "06.2025"
 
         val actualDate = financeDateProvider.previousMonth()
 
         assertThat(actualDate).isEqualTo(expectedDate)
 
-        val anotherFinanceDateProvider = FinanceDateProvider(LocalDate.of(2025, 1, 14))
+        val anotherFinanceDateProvider = FinanceDateProvider(MockEvakaClock(2025, 1, 14, 12, 34, 56))
         val anotherExpectedDate = "12.2024"
 
         val anotherActualDate = anotherFinanceDateProvider.previousMonth()
@@ -51,7 +53,7 @@ class FinanceDateProviderTest {
 
     @Test
     fun `should return date with correct abbreviated format`() {
-        val financeDateProvider = FinanceDateProvider(LocalDate.of(2025, 7, 14))
+        val financeDateProvider = FinanceDateProvider(MockEvakaClock(2025, 7, 14, 12, 34, 56))
         val expectedDate = "250714"
 
         val actualDate = financeDateProvider.currentDateWithAbbreviatedYear()
@@ -61,14 +63,17 @@ class FinanceDateProviderTest {
 
     @Test
     fun `should return correct last date of previous month`() {
-        val financeDateProvider = FinanceDateProvider(LocalDate.of(2025, 7, 14))
+        val financeDateProvider =
+            FinanceDateProvider(
+                MockEvakaClock(2025, 7, 14, 12, 34, 56),
+            )
         val expectedDate = "250630"
 
         val actualDate = financeDateProvider.previousMonthLastDate()
 
         assertThat(actualDate).isEqualTo(expectedDate)
 
-        val anotherFinanceDateProvider = FinanceDateProvider(LocalDate.of(2024, 3, 7))
+        val anotherFinanceDateProvider = FinanceDateProvider(MockEvakaClock(2024, 3, 7, 12, 34, 56))
         val anotherExpectedDate = "240229"
 
         val anotherActualDate = anotherFinanceDateProvider.previousMonthLastDate()
@@ -78,11 +83,20 @@ class FinanceDateProviderTest {
 
     @Test
     fun `should return correct previous month in YYMM format`() {
-        val financeDateProvider = FinanceDateProvider(LocalDate.of(2025, 7, 14))
+        val financeDateProvider = FinanceDateProvider(MockEvakaClock(2025, 7, 14, 12, 34, 56))
         val expectedDate = "2506"
 
         val actualDate = financeDateProvider.previousMonthYYMM()
 
         assertThat(actualDate).isEqualTo(expectedDate)
+    }
+
+    @Test
+    fun `should return different date tomorrow`() {
+        val mockClock = MockEvakaClock(2025, 7, 14, 12, 34, 56)
+        val financeDateProvider = FinanceDateProvider(mockClock)
+        assertThat("20250714").isEqualTo(financeDateProvider.currentDate())
+        mockClock.tick(Duration.ofHours(24))
+        assertThat("20250715").isEqualTo(financeDateProvider.currentDate())
     }
 }


### PR DESCRIPTION
The previous version would set its currentDate once when the system was started and stay stuck to that ever after. Use an EvakaClock to get the real current date instead